### PR TITLE
adapt key determining logic

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Run test
       run: |
         pip install pytest-cov
-        pytest --junitxml=pytest.xml --cov-report=term-missing:skip-covered --cov=inheritance_dict typetest.py
+        pytest --junitxml=pytest.xml --cov-fail-under=100 --cov-report=term-missing:skip-covered --cov=inheritance_dict typetest.py
     - name: Coveralls
       uses: coverallsapp/github-action@v2
   build:

--- a/inheritance_dict/__init__.py
+++ b/inheritance_dict/__init__.py
@@ -15,14 +15,13 @@ class InheritanceDict(dict):
         """
         Yield lookup candidate keys.
         
-        If `key` is a type, yields the classes in its method-resolution order (key.__mro__) in order;
-        otherwise yields the key itself. Used to produce the sequence of keys to try for dictionary
-        lookups that support type-based inheritance resolution.
+        If `key` is a type, yields the classes in its method-resolution order (key.__mro__) in
+        order; otherwise yields the key itself. Used to produce the sequence of keys to try for
+        dictionary lookups that support type-based inheritance resolution.
         """
         if isinstance(key, type):
             return key.__mro__
-        else:
-            return (key,)
+        return (key,)
 
     def __getitem__(self, key):
         """
@@ -96,12 +95,16 @@ class TypeConvertingInheritanceDict(InheritanceDict):
 
     def _get_keys(self, key):
         """
-        Yield candidate lookup keys for a given key, extending the base behavior by including the key's type MRO for non-type keys.
+        Yield candidate lookup keys for a given key, extending the base behavior by including the
+        key's type MRO for non-type keys.
         
-        For non-type keys, yields the candidates produced by the superclass (_e.g., the key itself_), followed by the method resolution order (MRO) of type(key). For keys that are types, yields only the superclass candidates (typically the type's MRO).
+        For non-type keys, yields the candidates produced by the superclass
+        (_e.g., the key itself_), followed by the method resolution order (MRO) of type(key).
+        For keys that are types, yields only the superclass candidates (typically the type's MRO).
         
         Parameters:
-            key: The lookup key. If `key` is not a `type`, this generator will include the MRO of `type(key)` after the superclass candidates.
+            key: The lookup key. If `key` is not a `type`, this generator will include the MRO of
+            `type(key)` after the superclass candidates.
         
         Yields:
             Candidate keys (types or other keys) in the order they should be tried for lookup.

--- a/inheritance_dict/__init__.py
+++ b/inheritance_dict/__init__.py
@@ -1,12 +1,13 @@
-from collections.abc import Iterable
-
-
-__all__ = ["InheritanceDict", "TypeConvertingInheritanceDict"]
-
 """
 The module defines an InheritanceDict, which is a dictionary, but for lookups where the key is a
 type, it will walk over the Method Resolution Order (MRO) looking for a value.
 """
+
+
+from collections.abc import Iterable
+
+
+__all__ = ["InheritanceDict", "TypeConvertingInheritanceDict"]
 
 MISSING = object()
 

--- a/inheritance_dict/__init__.py
+++ b/inheritance_dict/__init__.py
@@ -3,6 +3,8 @@ The module defines an InheritanceDict, which is a dictionary, but for lookups wh
 type, it will walk over the Method Resolution Order (MRO) looking for a value.
 """
 
+MISSING = object()
+
 
 class InheritanceDict(dict):
     """
@@ -32,10 +34,9 @@ class InheritanceDict(dict):
         using `key`. Raises KeyError if no matching mapping exists.
         """
         for item in self._get_keys(key):
-            try:
-                return super().__getitem__(item)
-            except KeyError:
-                pass
+            result = super().get(item, MISSING)
+            if result is not MISSING:
+                return result
         raise KeyError(key)
 
     def get(self, key, default=None):

--- a/inheritance_dict/__init__.py
+++ b/inheritance_dict/__init__.py
@@ -3,7 +3,6 @@ The module defines an InheritanceDict, which is a dictionary, but for lookups wh
 type, it will walk over the Method Resolution Order (MRO) looking for a value.
 """
 
-
 from collections.abc import Iterable
 
 

--- a/inheritance_dict/__init__.py
+++ b/inheritance_dict/__init__.py
@@ -1,7 +1,11 @@
+from collections.abc import Iterable
+
 """
 The module defines an InheritanceDict, which is a dictionary, but for lookups where the key is a
 type, it will walk over the Method Resolution Order (MRO) looking for a value.
 """
+
+__all__ = ["InheritanceDict", "TypeConvertingInheritanceDict"]
 
 MISSING = object()
 
@@ -13,7 +17,7 @@ class InheritanceDict(dict):
     type.
     """
 
-    def _get_keys(self, key):
+    def _get_keys(self, key) -> Iterable[object]:
         """
         Yield lookup candidate keys.
 

--- a/inheritance_dict/__init__.py
+++ b/inheritance_dict/__init__.py
@@ -1,11 +1,12 @@
 from collections.abc import Iterable
 
+
+__all__ = ["InheritanceDict", "TypeConvertingInheritanceDict"]
+
 """
 The module defines an InheritanceDict, which is a dictionary, but for lookups where the key is a
 type, it will walk over the Method Resolution Order (MRO) looking for a value.
 """
-
-__all__ = ["InheritanceDict", "TypeConvertingInheritanceDict"]
 
 MISSING = object()
 

--- a/inheritance_dict/__init__.py
+++ b/inheritance_dict/__init__.py
@@ -13,9 +13,9 @@ class InheritanceDict(dict):
 
     def _get_keys(self, key):
         if isinstance(key, type):
-            yield from key.__mro__
+            return key.__mro__
         else:
-            yield key
+            return (key,)
 
     def __getitem__(self, key):
         """
@@ -98,9 +98,6 @@ class TypeConvertingInheritanceDict(InheritanceDict):
     """
 
     def _get_keys(self, key):
-        result = super()._get_keys(key)
+        yield from super()._get_keys(key)
         if not isinstance(key, type):
-            yield from result
             yield from type(key).__mro__
-        else:
-            yield from result

--- a/inheritance_dict/__init__.py
+++ b/inheritance_dict/__init__.py
@@ -14,7 +14,7 @@ class InheritanceDict(dict):
     def _get_keys(self, key):
         """
         Yield lookup candidate keys.
-        
+
         If `key` is a type, yields the classes in its method-resolution order (key.__mro__) in
         order; otherwise yields the key itself. Used to produce the sequence of keys to try for
         dictionary lookups that support type-based inheritance resolution.
@@ -26,7 +26,7 @@ class InheritanceDict(dict):
     def __getitem__(self, key):
         """
         Return the value for `key`, using type inheritance when appropriate.
-        
+
         If `key` is a type, this performs lookups in the key's MRO (key.__mro__) in order and
         returns the first mapped value found. If `key` is not a type, it performs a direct lookup
         using `key`. Raises KeyError if no matching mapping exists.
@@ -97,15 +97,15 @@ class TypeConvertingInheritanceDict(InheritanceDict):
         """
         Yield candidate lookup keys for a given key, extending the base behavior by including the
         key's type MRO for non-type keys.
-        
+
         For non-type keys, yields the candidates produced by the superclass
         (_e.g., the key itself_), followed by the method resolution order (MRO) of type(key).
         For keys that are types, yields only the superclass candidates (typically the type's MRO).
-        
+
         Parameters:
             key: The lookup key. If `key` is not a `type`, this generator will include the MRO of
             `type(key)` after the superclass candidates.
-        
+
         Yields:
             Candidate keys (types or other keys) in the order they should be tried for lookup.
         """


### PR DESCRIPTION
adapt key determining logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Non-type key lookups in the inheritance-aware dictionaries now consider the key itself, its type, and the type’s inheritance chain, improving match coverage without extra setup.

* Refactor
  * Unified the lookup mechanism across implementations to use a common, generator-based resolution path for more consistent behavior.

* Documentation
  * Clarified lookup behavior for non-type keys, emphasizing consideration of the key’s type hierarchy.

* Chores
  * Streamlined internal overrides to reduce duplication while preserving existing public method behavior and error semantics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->